### PR TITLE
Adds option to set unconnected send timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,22 @@ PLC.connect("192.168.1.1", 0).then(async () => {
 });
 ```
 
+#### Using unconnected messaging with custom timeout
+
+```javascript
+const { Controller, Tag, TagList, Structure } = require("st-ethernet-ip");
+
+const PLC = new Controller(false, { unconnectedSendTimeout: 5064 });
+
+PLC.connect("192.168.1.1", 0).then(async () => {
+    
+    const sampleTag = new Tag("sampleTag");
+
+    await PLC.readTag(sampleTag);
+    console.log(sampleTag.value);
+});
+```
+
 ### New Device Browser
 
 #### Find Devices On The Network

--- a/src/controller/controller.spec.js
+++ b/src/controller/controller.spec.js
@@ -69,6 +69,16 @@ describe("Controller Class", () => {
 
             expect(plc.time).toMatchSnapshot();
         });
+
+        it("Default Unconnected Send timeout", () => {
+            const plc = new Controller();
+            expect(plc.state.unconnectedSendTimeout).toEqual(2000);
+        });
+
+        it("Custom Unconnected Send timeout", () => {
+            const plc = new Controller(true, { unconnectedSendTimeout: 5064 });
+            expect(plc.state.unconnectedSendTimeout).toEqual(5064);
+        });
     });
 
     describe("SendRRDataReceived Handler", () => {

--- a/src/controller/index.js
+++ b/src/controller/index.js
@@ -11,7 +11,14 @@ const compare = (obj1, obj2) => {
 };
 
 class Controller extends ENIP {
-    constructor(connectedMessaging = true) {
+
+    /**
+     * 
+     * @param {boolean} [connectedMessaging=true] whether to use connected or unconnected messaging
+     * @param {object} [opts]
+     * @param {number} [opts.unconnectedSendTimeout=2000]
+     */
+    constructor(connectedMessaging = true, opts = {}) {
         super();
 
         this.state = {
@@ -38,6 +45,7 @@ class Controller extends ENIP {
             timeout_sp: 10000, //ms
             rpi: 10,
             fwd_open_serial: 0,
+            unconnectedSendTimeout: opts.unconnectedSendTimeout || 2000,
         };
 
         this.workers = {
@@ -381,7 +389,7 @@ class Controller extends ENIP {
         let msg;
         const connected = super.established_conn;
         if (connected === false) {
-            msg = UnconnectedSend.build(data, this.state.controller.path);
+            msg = UnconnectedSend.build(data, this.state.controller.path, this.state.unconnectedSendTimeout);
         } else {
             msg = data;
         }


### PR DESCRIPTION
## Description, Motivation, and Context
Adds an option to the constructor of the `Controller` class, enabling us to customize the timeout value of unconnected messages. Some PLCs require this value to be bigger than the current default of 2000.

## How Has This Been Tested?
 - Unit test of `Controller` properly expanded
 - Tested against SoftLogix controller

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This is a work in progress, and I want some feedback (If yes, please mark it in the title -> e.g. `[WIP] Some awesome PR title`)

## Related Issue

#1 
