### PR TITLE
Fix expansion of BIT_STRING within structure

### DIFF
--- a/src/structure/index.js
+++ b/src/structure/index.js
@@ -145,7 +145,10 @@ class Structure extends Tag {
                     if (member.type.arrayDims > 0) {
                         let array = [];
                         for (let i = 0; i < member.info * 4; i+=4) {
-                            array.push(data.readUInt32LE(member.offset + i));
+                            let bitString32bitValue = data.readUInt32LE(member.offset + i);
+                            for (let j = 0; j < 32; j++) {
+                                array.push(!!(bitString32bitValue >> j & 0x01));
+                            }
                         }
                         structValues[member.name] = array;
                     } else {

--- a/src/structure/index.js
+++ b/src/structure/index.js
@@ -238,7 +238,12 @@ class Structure extends Tag {
                 case BIT_STRING:
                     if (member.type.arrayDims > 0) {
                         for (let i = 0; i < member.info; i++) {
-                            data.writeUInt32LE(structValues[member.name][i], member.offset + (i * 4));
+                            let bitString32bitValue = 0;
+                            for (let j = i*32; j < (i+1)*32; j++) {
+                                if (j > structValues[member.name].length) break;
+                                bitString32bitValue |= (structValues[member.name][j] & 1) << j;
+                            }
+                            data.writeUInt32LE(bitString32bitValue >>> 0, member.offset + (i * 4));
                         }
                     } else {
                         data.writeUInt32LE(structValues[member.name],member.offset);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When structure member of type BIT_STRING is expanded, this change will do so into a boolean array.

### Description, Motivation, and Context
For structure members of type BIT_STRING (BOOL[] in PLC), the read data was parsed as an array of 32 bit integers (one integer for every 32 bools).  If the same structure member is read directly with Tag("MyStruct.MyBits", null, BIT_STRING), the value is returned as a boolean array.  This change expands the BIT_STRING into a boolean array.

This change aligns the behavior of the structure expansion to be similar to that of the Tag parsing with the BIT_STRING type specified.

## How Has This Been Tested?
Tested against an L74 controller with v20 firmware.  Tested reading a BIT_ARRAY of length 32 and 64 (bits).

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This is a work in progress, and I want some feedback (If yes, please mark it in the title -> e.g. `[WIP] Some awesome PR title`)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/SerafinTech/ST-node-ethernet-ip/issues/7
