### PR TITLE
Issue21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "st-ethernet-ip",
-    "version": "2.4.9",
+    "version": "2.5.0",
     "description": "A simple node interface for Ethernet/IP.",
     "main": "./src/index.js",
     "scripts": {

--- a/src/tag-list/index.js
+++ b/src/tag-list/index.js
@@ -229,8 +229,14 @@ class TagList {
                 if (tag.type.structure && !this.templates[tag.type.code]) {
                     
                     const template = new Template();
-                    await template.getTemplate(PLC, tag.type.code).catch(reject); 
-                    this.templates[tag.type.code] = template;                  
+                    await template.getTemplate(PLC, tag.type.code).catch(e => {
+                        if (e.generalStatusCode == 5) {
+                            template = null
+                        } else {
+                            reject()
+                        }
+                    }); 
+                    if (template) this.templates[tag.type.code] = template;                  
                 }
             }
 

--- a/src/tag-list/index.js
+++ b/src/tag-list/index.js
@@ -233,7 +233,7 @@ class TagList {
                         if (e.generalStatusCode == 5) {
                             template = null
                         } else {
-                            reject()
+                            reject(e)
                         }
                     }); 
                     if (template) this.templates[tag.type.code] = template;                  

--- a/src/tag-list/index.js
+++ b/src/tag-list/index.js
@@ -228,7 +228,7 @@ class TagList {
             for (const tag of this.tags) {
                 if (tag.type.structure && !this.templates[tag.type.code]) {
                     
-                    const template = new Template();
+                    let template = new Template();
                     await template.getTemplate(PLC, tag.type.code).catch(e => {
                         if (e.generalStatusCode == 5) {
                             template = null


### PR DESCRIPTION
Fix error during reading template attributes

### Description, Motivation, and Context
Some PLCs would give an invalid path error when reading some template attributes.  Most likely on reserved system tags.  The fix skips reading the template if that specific error happens when reading the template attribute list.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This is a work in progress, and I want some feedback (If yes, please mark it in the title -> e.g. `[WIP] Some awesome PR title`)

