### PR TITLE
FIX: don't attempt to write to TCP socket on socket closed exceptions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "st-ethernet-ip",
-    "version": "2.5.1",
+    "version": "2.5.2",
     "description": "A simple node interface for Ethernet/IP.",
     "main": "./src/index.js",
     "scripts": {

--- a/src/enip/index.js
+++ b/src/enip/index.js
@@ -265,10 +265,19 @@ class ENIP extends Socket {
      */
     destroy(exception) {
         const { unregisterSession } = encapsulation;
-        this.write(unregisterSession(this.state.session.id), () => {
+        const unregisteredSession = unregisterSession(this.state.session.id)
+
+        const onClose = () => {
             this.state.session.established = false;
             super.destroy(exception);
-        });
+        }
+
+        // Only write to the socket if is not closed. 
+        if (exception && !exception.code === "EPIPE") {
+            this.write(unregisteredSession, onClose);    
+        } else {            
+            onClose()
+        }
     }
     // endregion
 

--- a/src/enip/index.js
+++ b/src/enip/index.js
@@ -265,18 +265,18 @@ class ENIP extends Socket {
      */
     destroy(exception) {
         const { unregisterSession } = encapsulation;
-        const unregisteredSession = unregisterSession(this.state.session.id)
+        const unregisteredSession = unregisterSession(this.state.session.id);
 
         const onClose = () => {
             this.state.session.established = false;
             super.destroy(exception);
-        }
+        };
 
         // Only write to the socket if is not closed. 
         if (exception && !exception.code === "EPIPE") {
             this.write(unregisteredSession, onClose);    
         } else {            
-            onClose()
+            onClose();
         }
     }
     // endregion


### PR DESCRIPTION
If the TCP socket closed unexpectedly, the ENIP class's `destroy` function attempts to write to the socket, triggering an exception, resulting in an endless loop and `Maximum Callstack Size Exceeded` error.
### Description, Motivation, and Context

When attempting to set up node-red with an eth/ip connection, I discovered that closing the simulator app while connected crashed node-red. This turned out to be due to the issue described above.

So, of `destroy` is called by an `EPIPE` exception, don't try to write to the socket.

## How Has This Been Tested?

* Installed the `node-red-contrib-cip-st-ethernet-ip` in node-red.
* Set up an eth/ip connection with a simulator
* Disconnected the simulator, triggering the behavior
* Fixed the issue
* Verified that disconnecting the simulator did not crash node-red, that on restarting the simulator, eth-ip connectivity resumed. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] All new and existing, passing tests passed. *`Npm run test` finds the same number of errors as before.*

## Related Issue
https://github.com/SerafinTech/ST-node-ethernet-ip/issues/29
