### PR TITLE
Add additional data types support

### DIFF
--- a/src/tag/index.ts
+++ b/src/tag/index.ts
@@ -603,7 +603,8 @@ export class Tag extends EventEmitter {
                     }
                 } else {
                     //empty string, data[2] will be 0 as well, as it is the string length
-                    this.controller_value = null;
+                    //return empty string instead of null
+                    this.controller_value = '';//null;
                 }
                 break;
             default:

--- a/src/tag/index.ts
+++ b/src/tag/index.ts
@@ -625,8 +625,7 @@ export class Tag extends EventEmitter {
      * @memberof Tag
      */
     generateWriteMessageRequest(value: any = null, size: number = 0x01): Buffer {
-        // allow null value for short string
-        if (value !== null || this.state.tag.type === Types.SHORT_STRING) {
+        if (value !== null) {
             this.state.tag.value = value;
         } 
 

--- a/src/tag/index.ts
+++ b/src/tag/index.ts
@@ -494,7 +494,7 @@ export class Tag extends EventEmitter {
      * @param Data - Returned from Successful Read Tag Request
      */
     parseReadMessageResponseValueForAtomic(data: Buffer) {
-        const { SINT, INT, DINT, REAL, BOOL, LINT, BIT_STRING, UINT, SHORT_STRING } = Types;
+        const { SINT, INT, DINT, REAL, BOOL, LINT, BIT_STRING, UINT, SHORT_STRING, USINT } = Types;
 
         const { read_size } = this.state;
 
@@ -512,6 +512,17 @@ export class Tag extends EventEmitter {
                     this.controller_value = data.readInt8(2);
                 }
                 break;
+            case USINT:
+                    if (data.length > 3) {
+                        const array = [];
+                        for (let i = 0; i < data.length - 2; i++) {
+                            array.push(data.readUInt8(i + 2));
+                        }
+                        this.controller_value = array;
+                    } else {
+                        this.controller_value = data.readUInt8(2);
+                    }
+                    break;
             case UINT:
                 if (data.length > 4) {
                     const array = [];
@@ -684,7 +695,7 @@ export class Tag extends EventEmitter {
      */
     generateWriteMessageRequestForAtomic(value: any, size: number) {
         const { tag } = this.state;
-        const { SINT, INT, DINT, REAL, BOOL, LINT, SHORT_STRING } = Types;
+        const { SINT, INT, DINT, REAL, BOOL, LINT, SHORT_STRING, USINT } = Types;
         // Build Message Router to Embed in UCMM
         let buf = Buffer.alloc(4);
         let valBuf = null;
@@ -703,7 +714,7 @@ export class Tag extends EventEmitter {
                 if (Array.isArray(value)) {
                     valBuf = Buffer.alloc(value.length);
                     for (var i = 0; i < value.length; i++) {
-                        valBuf.writeUInt8(value[i], i);
+                        valBuf.writeInt8(value[i], i);
                     }
                 } else {
                     valBuf = Buffer.alloc(1);
@@ -711,6 +722,18 @@ export class Tag extends EventEmitter {
                 }
                 buf = Buffer.concat([buf, valBuf]);
                 break;
+            case USINT:
+                    if (Array.isArray(value)) {
+                        valBuf = Buffer.alloc(value.length);
+                        for (var i = 0; i < value.length; i++) {
+                            valBuf.writeUInt8(value[i], i);
+                        }
+                    } else {
+                        valBuf = Buffer.alloc(1);
+                        valBuf.writeUInt8(tag.value);                    
+                    }
+                    buf = Buffer.concat([buf, valBuf]);
+                    break;
             case INT:
                 if (Array.isArray(value)) {
                     valBuf = Buffer.alloc(2 * value.length);


### PR DESCRIPTION
The SHORT_STRING data type is a single byte character string. It is sent with the first byte being the length, followed by the string data. Supporting symbolic (Rockwell) tags with this data type is relatively straightforward. Also add support for USINT (unsigned 8bit data) 

There was also a change for writing SINT data, the code used Buffer.writeUInt8 when I think it should have used Buffer.writeInt8.

Further testing should probably be done, as I've only be able to test using the Micro850 simulator in Connected Components Workbench.

Tested with
CCW version 22
PLC - 2080-LC50-48QWB-SIM (Micro850 Simulator, not actual hardware)