### PR TITLE
Update index.ts

### DIFF
--- a/src/tag-list/index.ts
+++ b/src/tag-list/index.ts
@@ -281,14 +281,10 @@ class TagList {
     _getAllTemplates (PLC: Controller): Promise<void> {
         return new Promise (async (resolve, reject) => {
             for (const tag of this.tags) {
-                if (tag.type.structure && !this.templates[tag.type.code]) {
-
-                    try {
-                        const template = new Template();
-                        await template.getTemplate(PLC, tag.type.code);
-                        this.templates[tag.type.code] = template;
-                    } catch (e) { /* ignore template fetching errors */ }              
-
+                if (tag.type.structure && !this.templates[tag.type.code]) {                    
+					const template = new structure_1.Template();
+					await template.getTemplate(PLC, tag.type.code).catch((e) => { /* ignore template fetching errors */ });
+					this.templates[tag.type.code] = template;
                 }
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description, Motivation, and Context
In _getAllTemplates changed try catch with .catch on first call to template.getTemplate, because template.getTemplate is a promise, with externally try catch the error is not catched.

If you use this node in node-red (for example using node-red-contrib-cip-st-ethernet-ip), node-red crash with Uncaught Exception

## How Has This Been Tested?
I try this commit with my test environment (I have some rockwell plc that I read from like 1756-L82ES and 1756-L81ES)

- Node.js 18.19.0
- Node-red 3.1.3
- Windows 11 x64
- node-red-contrib-cip-st-ethernet-ip 2.0.2

This commit works in case of #21 : I think that try catch is inserted to resolve this issue.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This is a work in progress, and I want some feedback (If yes, please mark it in the title -> e.g. `[WIP] Some awesome PR title`)

## Related Issue
Major issue is Uncaught Exception on node-red
